### PR TITLE
Rename console.phar to drupal.phar

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,7 +14,7 @@
 
 - name: Move Drupal Console into globally-accessible location.
   shell: >
-    mv console.phar {{ drupal_console_path }}
+    mv drupal.phar {{ drupal_console_path }}
     creates={{ drupal_console_path }}
 
 - name: Update Drupal Console to latest version (if configured).


### PR DESCRIPTION
Fix after drupalconsole.com renamed installer file downloaded from http://drupalconsole.com/installer
