### PR TITLE
Replaced curl call with get_url.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,6 @@ env:
 
 before_install:
   - sudo apt-get update -qq
-  - sudo apt-get install curl
 
 install:
   # Install Ansible.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Installs [Drupal Console](http://drupalconsole.com/) on any Linux or UNIX system
 
 ## Requirements
 
-`curl` and `php` (version 5.4+) should be installed and working.
+`php` (version 5.4+) should be installed and working.
 
 ## Role Variables
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,21 +1,8 @@
 ---
-- name: Ensure curl is installed (RedHat).
-  yum: name=curl state=installed
-  when: ansible_os_family == 'RedHat'
-
-- name: Ensure curl is installed (Debian).
-  apt: name=curl state=installed
-  when: ansible_os_family == 'Debian'
-
-- name: Install Drupal Console into the current directory.
-  shell: >
-    curl https://drupalconsole.com/installer -L -o drupal.phar
-    creates={{ drupal_console_path }}
-
-- name: Move Drupal Console into globally-accessible location.
-  shell: >
-    mv drupal.phar {{ drupal_console_path }}
-    creates={{ drupal_console_path }}
+- name: Install Drupal Console.
+  get_url:
+    url=https://drupalconsole.com/installer
+    dest={{ drupal_console_path }}
 
 - name: Ensure Drupal Console is executable.
   file:


### PR DESCRIPTION
Ansible throws a warning on use of curl. Replaced curl with get_url,
which also removes the need to check if curl is installed.
